### PR TITLE
Add swagger UI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,11 @@
 		<java.version>17</java.version>
 	</properties>
 	<dependencies>
+<!--		<dependency>-->
+<!--			<groupId>org.hibernate</groupId>-->
+<!--			<artifactId>hibernate-validator</artifactId>-->
+<!--			<version>8.0.0.Final</version>-->
+<!--		</dependency>-->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
@@ -45,6 +50,17 @@
 			<artifactId>mysql-connector-java</artifactId>
 			<version>8.0.32</version>
 			<scope>runtime</scope>
+		</dependency>
+		<!-- integration with Swagger API doc generation http://goo.gl/J5FQDM -->
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger2</artifactId>
+			<version>3.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.0.2</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/dreamso/smartworker/controller/UserController.java
+++ b/src/main/java/com/dreamso/smartworker/controller/UserController.java
@@ -18,6 +18,7 @@ public class UserController {
     UserService userService;
 
     @GetMapping("/users")
+    @ApiOperation(value = "Get all users.", notes = "Returns user list")
     public List<User> getUsers() {
         return userService.getUsers();
     }
@@ -25,6 +26,7 @@ public class UserController {
 
     @PostMapping("/users")
     @ResponseStatus(HttpStatus.CREATED)
+    @ApiOperation(value = "Create a User resource.", notes = "Returns the User")
     public User createUser(@RequestBody User user) {
         return userService.createUser(user);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,6 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 
 # Hibernate ddl auto (create, create-drop, validate, update)
 spring.jpa.hibernate.ddl-auto = update
+
+# swagger-ui custom path
+#springdoc.swagger-ui.path=/swagger-ui.html


### PR DESCRIPTION
## Description
Inegrate swagger UI.
Now can see the swagger UI of the APIs from following URL:

`http://localhost:8080/swagger-ui`

### Fixes
- https://github.com/Dream-SO/product-smart-worker/issues/1